### PR TITLE
 replace asserts with granular error handling 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ repository = "https://github.com/roman901/vpk-rs"
 edition = "2018"
 
 [dependencies]
-byteorder = "1.3.4"
 thiserror = "1.0.20"
+binread = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.3.4"
+thiserror = "1.0.20"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
-use std::io::{Error, Read, Seek, SeekFrom, self};
-use byteorder::{ReadBytesExt, LittleEndian};
+use std::io::{Error, Read, Seek, SeekFrom};
+use binread::BinRead;
 
 #[derive(Debug)]
 pub struct VPKEntry {
@@ -25,7 +25,7 @@ impl Read for VPKEntry {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, BinRead)]
 pub struct VPKDirectoryEntry {
     pub crc32: u32,
     pub preload_length: u16,
@@ -33,17 +33,4 @@ pub struct VPKDirectoryEntry {
     pub archive_offset: u32,
     pub file_length: u32,
     pub suffix: u16,
-}
-
-impl VPKDirectoryEntry {
-    pub fn read(reader: &mut impl Read) -> io::Result<Self> {
-        Ok(VPKDirectoryEntry {
-            crc32: reader.read_u32::<LittleEndian>()?,
-            preload_length: reader.read_u16::<LittleEndian>()?,
-            archive_index: reader.read_u16::<LittleEndian>()?,
-            archive_offset: reader.read_u32::<LittleEndian>()?,
-            file_length: reader.read_u32::<LittleEndian>()?,
-            suffix: reader.read_u16::<LittleEndian>()?,
-        })
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ use std::path::Path;
 pub enum Error {
     #[error("Error while trying to read data: {0}")]
     ReadError(#[from] std::io::Error),
+    #[error("Error while trying to read data: {0}")]
+    BinReadError(#[from] binread::Error),
     #[error("Invalid signature, provided file is not a VPK file")]
     InvalidSignature,
     #[error("Unsupported VPK version({0}), only version 2 and low")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,22 @@ mod vpk;
 
 use crate::vpk::VPK;
 
-use std::io::Error;
+use thiserror::Error;
 use std::path::Path;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Error while trying to read data: {0}")]
+    ReadError(#[from] std::io::Error),
+    #[error("Invalid signature, provided file is not a VPK file")]
+    InvalidSignature,
+    #[error("Unsupported VPK version({0}), only version 2 and low")]
+    UnsupportedVersion(u32),
+    #[error("Mismatched size for hashes section")]
+    HashSizeMismatch,
+    #[error("Malformed index encountered while parsing")]
+    MalformedIndex
+}
 
 pub fn from_path(path: &str) -> Result<VPK, Error> {
     let path = Path::new(path);

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,24 +1,13 @@
-use std::io::{self, Read};
-use byteorder::{ReadBytesExt, LittleEndian};
+use binread::BinRead;
 
-#[derive(Debug)]
+#[derive(Debug, BinRead)]
 pub struct VPKHeader {
     pub signature: u32,
     pub version: u32,
     pub tree_length: u32,
 }
 
-impl VPKHeader {
-    pub fn read(reader: &mut impl Read) -> io::Result<Self> {
-        Ok(VPKHeader {
-            signature: reader.read_u32::<LittleEndian>()?,
-            version: reader.read_u32::<LittleEndian>()?,
-            tree_length: reader.read_u32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, BinRead)]
 pub struct VPKHeaderV2 {
     pub embed_chunk_length: u32,
     pub chunk_hashes_length: u32,
@@ -26,30 +15,9 @@ pub struct VPKHeaderV2 {
     pub signature_length: u32,
 }
 
-impl VPKHeaderV2 {
-    pub fn read(reader: &mut impl Read) -> io::Result<Self> {
-        Ok(VPKHeaderV2 {
-            embed_chunk_length: reader.read_u32::<LittleEndian>()?,
-            chunk_hashes_length: reader.read_u32::<LittleEndian>()?,
-            self_hashes_length: reader.read_u32::<LittleEndian>()?,
-            signature_length: reader.read_u32::<LittleEndian>()?,
-        })
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, BinRead)]
 pub struct VPKHeaderV2Checksum {
     pub tree_checksum: u128,
     pub chunk_hashes_checksum: u128,
     pub file_checksum: u128,
-}
-
-impl VPKHeaderV2Checksum {
-    pub fn read(reader: &mut impl Read) -> io::Result<Self> {
-        Ok(VPKHeaderV2Checksum {
-            tree_checksum: reader.read_u128::<LittleEndian>()?,
-            chunk_hashes_checksum: reader.read_u128::<LittleEndian>()?,
-            file_checksum: reader.read_u128::<LittleEndian>()?,
-        })
-    }
 }


### PR DESCRIPTION
instead of panicing with the assert, allow the user to handle malformed vpk errors.

Since this adds the `syn` and friends proc-macro dependencies anyway, might as well use those to implement reading for the structs.