### PR TITLE
Improve performance of parsing vpk directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,18 @@ edition = "2018"
 [dependencies]
 thiserror = "1.0.20"
 binread = "1.0.1"
+
+[dev-dependencies]
+iai = "0.1.0"
+criterion = "0.3"
+
+[[bench]]
+name = "parse"
+harness = false
+
+[[bench]]
+name = "iai"
+harness = false
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 thiserror = "1.0.20"
 binread = "1.0.1"
+ahash = "0.7.6"
 
 [dev-dependencies]
 iai = "0.1.0"

--- a/benches/iai.rs
+++ b/benches/iai.rs
@@ -1,0 +1,8 @@
+use iai::black_box;
+use vpk::VPK;
+
+fn parse_dir() {
+    VPK::read(black_box("tf2_misc_dir.vpk".as_ref())).unwrap();
+}
+
+iai::main!(parse_dir);

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,11 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use vpk::VPK;
+
+fn parse_vpk(c: &mut Criterion) {
+    c.bench_function("parse vpk", |b| {
+        b.iter(|| VPK::read(black_box("tf2_misc_dir.vpk".as_ref())).unwrap())
+    });
+}
+
+criterion_group!(benches, parse_vpk);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub use crate::vpk::VPK;
 
 use thiserror::Error;
 use std::path::Path;
+use std::string::FromUtf8Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -21,7 +22,9 @@ pub enum Error {
     #[error("Mismatched size for hashes section")]
     HashSizeMismatch,
     #[error("Malformed index encountered while parsing")]
-    MalformedIndex
+    MalformedIndex,
+    #[error("Invalid utf8 string found while parsing")]
+    Utf(#[from] FromUtf8Error)
 }
 
 pub fn from_path(path: &str) -> Result<VPK, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::vpk::VPK;
 
 use thiserror::Error;
 use std::path::Path;
-use std::string::FromUtf8Error;
+use std::str::Utf8Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -24,7 +24,7 @@ pub enum Error {
     #[error("Malformed index encountered while parsing")]
     MalformedIndex,
     #[error("Invalid utf8 string found while parsing")]
-    Utf(#[from] FromUtf8Error)
+    Utf(#[from] Utf8Error)
 }
 
 pub fn from_path(path: &str) -> Result<VPK, Error> {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,6 +1,6 @@
 use binread::BinRead;
 
-#[derive(Debug, BinRead)]
+#[derive(Debug, BinRead, Copy, Clone)]
 pub struct VPKHeader {
     pub signature: u32,
     pub version: u32,

--- a/src/vpk.rs
+++ b/src/vpk.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::mem;
 use std::path::Path;
+use ahash::RandomState;
 use binread::BinReaderExt;
 
 const VPK_SIGNATURE: u32 = 0x55aa1234;
@@ -18,7 +19,7 @@ pub struct VPK {
     pub header: VPKHeader,
     pub header_v2: Option<VPKHeaderV2>,
     pub header_v2_checksum: Option<VPKHeaderV2Checksum>,
-    pub tree: HashMap<String, VPKEntry>,
+    pub tree: HashMap<String, VPKEntry, RandomState>,
 }
 
 impl VPK {
@@ -42,7 +43,7 @@ impl VPK {
             header,
             header_v2: None,
             header_v2_checksum: None,
-            tree: HashMap::new(),
+            tree: HashMap::with_capacity_and_hasher(0, RandomState::new()),
         };
 
         if vpk.header.version == 2 {

--- a/src/vpk.rs
+++ b/src/vpk.rs
@@ -43,7 +43,7 @@ impl VPK {
             header,
             header_v2: None,
             header_v2_checksum: None,
-            tree: HashMap::with_capacity_and_hasher(0, RandomState::new()),
+            tree: HashMap::with_capacity_and_hasher(header.tree_length as usize / 50, RandomState::new()),
         };
 
         if vpk.header.version == 2 {


### PR DESCRIPTION
Improves the performance of reading the vpk directory by about 6x

- switch to ahash for the tree hashmap
- read entire tree data in one go
- optimize string reading and don't allocate for intermediate strings
